### PR TITLE
Added support for multiple events at the same time.

### DIFF
--- a/jquery.quicksearch.js
+++ b/jquery.quicksearch.js
@@ -7,7 +7,7 @@
 			stripeRows: null,
 			loader: null,
 			noResults: '',
-			bind: ['keyup','input','mouseup','change'],
+			bind: 'keyup input mouseup change',
 			onBefore: function () { 
 				return;
 			},
@@ -147,14 +147,7 @@
 				}
 			};
 			
-			if ( typeof(options.bind) == "string" ) {
-				self.bind(options.bind, handler);
-			}
-			else {
-				options.bind.each(function(eventName){
-					self.bind(eventName, handler);
-				});
-			}
+			self.bind(options.bind, handler);
 		});
 		
 	};


### PR DESCRIPTION
Before this fix, pasting text into a field with the mouse (right click +
paste) didn't trigger the event.
Some other plugins like clearableTextField
(https://github.com/ono/clearable_text_field/) only trigger the "change"
event which didn't refresh the search.
