### PR TITLE
Clearsearch Functionality

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -73,6 +73,8 @@ the form and input are not build by the script any more.
 	A query selector to find a loading element
 *	#### noResults
 	A query selector to show if there's no results for the search
+*	#### clearSearch
+	A query selector to use for clearing your search term.  Will only display with 1 or more search characters
 *	#### bind
 	Event that the trigger is tied to
 *	#### onBefore
@@ -101,6 +103,7 @@ For example:
 		'stripeRows': ['odd', 'even'],
 		'loader': 'span.loading',
 		'noResults': 'tr#noresults',
+		'clearSearch': 'a.clearsearch',
 		'bind': 'keyup keydown',
 		'onBefore': function () {
 			console.log('on before');

--- a/examples/index.html
+++ b/examples/index.html
@@ -22,6 +22,7 @@
 					'delay': 300,
 					'selector': 'th',
 					'stripeRows': ['odd', 'even'],
+					'clearSearch': 'a.clearsearch',
 					'loader': 'span.loading',
 					'bind': 'keyup click',
 					'show': function () {
@@ -314,7 +315,7 @@ $('input#id_search').quicksearch('table#table_example tbody tr');
 
 <form action="#">
 	<fieldset>
-		<input type="text" name="search" value="" id="id_search2" /> <span class="loading">Loading...</span>
+		<input type="text" name="search" value="" id="id_search2" /> <a href="#" class="clearsearch">X</a> <span class="loading">Loading...</span>
 	</fieldset>
 </form>
 
@@ -552,6 +553,7 @@ $('input#id_search2').quicksearch('table#table_example2 tbody tr', {
 	'delay': 300,
 	'selector': 'th',
 	'stripeRows': ['odd', 'even'],
+	'clearSearch': 'a.clearsearch',
 	'loader': 'span.loading',
 	'bind': 'keyup click',
 	'show': function () {

--- a/examples/super_table.html
+++ b/examples/super_table.html
@@ -8,6 +8,7 @@
 			$(document).ready(function () {
 				$("#id_search").quicksearch("table tbody tr", {
 					noResults: '#noresults',
+					clearSearch: 'a.clearsearch',
 					stripeRows: ['odd', 'even'],
 					loader: 'span.loading'
 				});
@@ -20,7 +21,7 @@
 	
 		<form action="#">
 			<fieldset>
-				<input type="text" name="search" value="" id="id_search" /> <span class="loading">Loading...</span>
+				<input type="text" name="search" value="" id="id_search" /> <a href="#" class="clearsearch">X</a> <span class="loading">Loading...</span>
 			</fieldset>
 		</form>	
 		

--- a/jquery.quicksearch.js
+++ b/jquery.quicksearch.js
@@ -1,3 +1,4 @@
+//https://github.com/riklomas/quicksearch
 (function($, window, document, undefined) {
 	$.fn.quicksearch = function (target, opt) {
 		
@@ -7,6 +8,7 @@
 			stripeRows: null,
 			loader: null,
 			noResults: '',
+			clearSearch: '', 
 			bind: 'keyup',
 			onBefore: function () { 
 				return;
@@ -39,7 +41,15 @@
 			noresults = true, 
 			query = options.prepareQuery(val),
 			val_empty = (val.replace(' ', '').length === 0);
-			
+
+			if(options.clearSearch.length !== 0) {
+				if (val_empty) {
+					$(options.clearSearch).hide();
+				} else {
+					$(options.clearSearch).show();
+				}
+			}
+
 			for (var i = 0, len = rowcache.length; i < len; i++) {
 				if (val_empty || options.testQuery(query, cache[i], rowcache[i])) {
 					options.show.apply(rowcache[i]);
@@ -60,6 +70,16 @@
 			options.onAfter();
 			
 			return this;
+		};
+
+		this.clear_search = function() {
+			if(options.clearSearch.length !== 0) {
+				$(options.clearSearch).bind('click', function(el) {
+					el.preventDefault();
+					val = '';
+					e.val('').go();
+				});
+			}
 		};
 		
 		this.stripe = function () {
@@ -137,6 +157,7 @@
 		this.results(true);
 		this.stripe();
 		this.loader(false);
+		this.clear_search();
 		
 		return this.each(function () {
 			$(this).bind(options.bind, function () {


### PR DESCRIPTION
Added ability to define clearSearch selector.  This selector can be used to clear an existing search.  The selector will not display unless there is 1 or more search characters.
