### PR TITLE
Page reload - rows not filtered

### DIFF
--- a/jquery.quicksearch.js
+++ b/jquery.quicksearch.js
@@ -117,6 +117,13 @@
 			rowcache = jq_results.map(function () {
 				return this;
 			});
+
+			if (!val) {
+				var temp = this.val();
+				if (temp) {
+					val = temp;
+				}
+			}
 			
 			return this.go();
 		};


### PR DESCRIPTION
I found a situation in which the variable "val" is empty, but "this.val()" could return the value contained in the search textbox. The textbox is within an ASP.net webform with viewstate enabled.

The scenario:
The application is using a Gridview and FormView control. Enter text into search box and see rows filtered.
View the contents of one of the rows which loads the FormView and hides the table.
Close the FormView and the table is not filtered.

For the search box I changed the bind from "keyup" to "keyup load" which should fire on the page refresh.
