### PR TITLE
Improved noResults option to accept jquery dom elements in addition to string identifiers

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -63,29 +63,29 @@ the form and input are not build by the script any more.
 
 ## Options
 
-* 	#### delay
+* 	**delay**
 	Delay of trigger in milliseconds
-*	#### selector
+*	**selector**
 	A query selector on sibling elements to test
-*	#### stripeRows
+*	**stripeRows**
 	An array of class names to go on each row
-*	#### loader
+*	**loader**
 	A query selector to find a loading element
-*	#### noResults
+*	**noResults**
 	A query selector to show if there's no results for the search
-*	#### bind
+*	**bind**
 	Event that the trigger is tied to
-*	#### onBefore
+*	**onBefore**
 	Function to call before trigger is called
-*	#### onAfter
+*	**onAfter**
 	Function to call after trigger is called
-*	#### show
+*	**show**
 	Function that will add styles to matched elements
-*	#### hide
+*	**hide**
 	Function that will add styles to unmatched elements
-*	#### prepareQuery
+*	**prepareQuery**
 	Function that transforms text from input_selector into query used by 'testQuery' function
-*	#### testQuery
+*	**testQuery**
 	Function that tells if a given item should be hidden
 	It takes 3 arguments:
 	- query prepared by 'prepareQuery'

--- a/jquery.quicksearch.js
+++ b/jquery.quicksearch.js
@@ -62,7 +62,6 @@
 			this.matchedResultsCount = numMatchedRows;
 			this.loader(false);
 			options.onAfter();
-			
 			return this;
 		};
 		
@@ -104,13 +103,22 @@
 		};
 		
 		this.results = function (bool) {
-			if (typeof options.noResults === "string" && options.noResults !== "") {
+			
+			if (options.noResults) {
+				
+				var noResultsEl = options.noResults;
+				
+				if (typeof options.noResults === "string") {
+					noResultsEl = $(options.noResults);
+				} 
+				
 				if (bool) {
-					$(options.noResults).hide();
+					noResultsEl.hide();
 				} else {
-					$(options.noResults).show();
+					noResultsEl.show();
 				}
 			}
+			
 			return this;
 		};
 		
@@ -121,15 +129,16 @@
 			return this;
 		};
 		
-		this.cache = function () {
+		this.cache = function (doRedraw) {
 			
-			jq_results = $(target);
+			doRedraw = (typeof doRedraw === "undefined") ? true : doRedraw;
 			
-			if (typeof options.noResults === "string" && options.noResults !== "") {
-				jq_results = jq_results.not(options.noResults);
-			}
+			jq_results = options.noResults ? $(target).not(options.noResults) : $(target);
 			
-			var t = (typeof options.selector === "string") ? jq_results.find(options.selector) : $(target).not(options.noResults);
+			var t = (typeof options.selector === "string") 
+						? jq_results.find(options.selector) 
+						: $(target).not(options.noResults);
+						
 			cache = t.map(function () {
 				return e.strip_html(this.innerHTML);
 			});
@@ -144,7 +153,11 @@
 			 * */
 			val = val || this.val() || "";
 			
-			return this.go();
+			if (doRedraw) {
+				this.go();
+			}
+			
+			return this;
 		};
 		
 		this.trigger = function () {


### PR DESCRIPTION
- Currently `noResults` option accepts only string identifiers. New changes will accept jQuery dom elements as well.
- Added a flag for deciding whether or not to redraw of the results when `cache` method is called. By default it always redraws.
- Cleaned up formatting of README
