### PR TITLE
Added condition to be able to work with multiselect plugin

### DIFF
--- a/jquery.quicksearch.js
+++ b/jquery.quicksearch.js
@@ -44,9 +44,11 @@
 			
 			for (var i = 0, len = rowcache.length; i < len; i++) {
 				if (val_empty || options.testQuery(query, cache[i], rowcache[i])) {
+				  if(!jQuery(rowcache[i]).is('.ms-elem-selectable.ms-selected')){
 					options.show.apply(rowcache[i]);
 					noresults = false;
 					numMatchedRows++;
+				  }
 				} else {
 					options.hide.apply(rowcache[i]);
 				}


### PR DESCRIPTION
What was happening is once we select one option in one of the multiselect box it was then hidden from it as expected to work.
But when we search for the element in the same box it shows up
Now I have added condition

`if(!jQuery(rowcache[i]).is('.ms-elem-selectable.ms-selected'))`

to be able to work with multiselect plugin. (https://github.com/lou/multi-select)